### PR TITLE
fix(300): use bootstrap date picker

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "angular-dragdrop": "~1.0.12",
     "ng-csv": "~0.3.4",
     "angular-csv-import": "~0.0.16",
-    "angular-xeditable": "~0.1.9",
+    "angular-xeditable": "https://github.com/tlvince/angular-xeditable.git#bd328b25ec309c437b9d1a96bedb0a019768e9a0",
     "angular-eha.couchdb-auth": "~1.1.0",
     "angular-ui-grid": "ui-grid#~3.0.7",
     "ui-select": "angular-ui-select#~0.13.2",

--- a/src/app/planning/schedule/index.html
+++ b/src/app/planning/schedule/index.html
@@ -75,9 +75,17 @@
           <td ng-bind="::facRnd.facility.name"></td>
           <td ng-bind="::facRnd.facility.id"></td>
           <td>
-            <a href="#" editable-date="facRnd.date" e-name="deliveryDate" e-form="rowform">
-              {{ srCtrl.getDate(facRnd.date) }}
-            </a>
+            <span
+              ng-bind="srCtrl.getDate(facRnd.date)"
+              editable-bsdate="facRnd.date"
+              e-name="deliveryDate"
+              e-form="rowform"
+              e-init-date="false"
+              e-datepicker-popup
+              e-ng-click="dateOpened = !dateOpened"
+              e-is-open="dateOpened"
+              buttons="no"
+            ></span>
           </td>
           <td>
           <span editable-select="facRnd.driverID"


### PR DESCRIPTION
HTML5 date type is only supported by Chrome.

Use angular-xeditable + ui-bootstrap ngClick workaround[1](https://github.com/vitalets/angular-xeditable/issues/164#issuecomment-125220958), plus a fork that
makes the input button optional[2](https://github.com/vitalets/angular-xeditable/pull/388) as we have space constraints.

Closes #300.
