### PR TITLE
chore: gzip build assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ deploy:
     region: eu-west-1
     local-dir: dist
     skip_cleanup: true
+    detect_encoding: true
     on:
       repo: eHealthAfrica/direct-delivery-dashboard
       branch: develop
@@ -28,6 +29,7 @@ deploy:
     region: eu-west-1
     local-dir: dist
     skip_cleanup: true
+    detect_encoding: true
     on:
       repo: eHealthAfrica/direct-delivery-dashboard
       branch: master
@@ -39,6 +41,7 @@ deploy:
     region: eu-west-1
     local-dir: dist
     skip_cleanup: true
+    detect_encoding: true
     on:
       repo: eHealthAfrica/direct-delivery-dashboard
       tags: true

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -9,3 +9,4 @@ else
 fi
 
 npm run build
+gzip -r dist


### PR DESCRIPTION
gzip the entire dist directory before uploading to S3. Only do this in Travis as
serving `dist` locally (with a dumb server) is occasionally useful.

@norbert, does this work for you?

Closes #371.
