### PR TITLE
refactor(log): use debug console log level

### DIFF
--- a/src/app/components/log/log.service.js
+++ b/src/app/components/log/log.service.js
@@ -27,7 +27,7 @@ angular.module('log')
       }
       text = text.join('. ') + '.'
 
-      $log[type.log](text, message, context)
+      $log.debug(text, message, context)
       return toastr[type.toastr](text, message.title)
     }
 


### PR DESCRIPTION
So it can be disabled with `$logProvider.debugEnabled(false)`.
